### PR TITLE
Fix most non-typechecking session types examples

### DIFF
--- a/examples/AIPL14/LectureExamples/calc.links
+++ b/examples/AIPL14/LectureExamples/calc.links
@@ -22,4 +22,4 @@ fun user(s) {
   x
 }
 
-user(fork (calc))
+user(forkSync (calc))

--- a/examples/AIPL14/LectureExamples/reccalc.links
+++ b/examples/AIPL14/LectureExamples/reccalc.links
@@ -29,4 +29,4 @@ fun user(s) {
   v
 }
 
-user(fork(calc))
+user(forkSync(calc))

--- a/examples/AIPL14/LectureExamples/two-factor.links
+++ b/examples/AIPL14/LectureExamples/two-factor.links
@@ -166,7 +166,7 @@ fun badMe(c) {
 
 sig serveData : ((~TwoFactor) ~e~> Int) ~e~> Int
 fun serveData(user) {
-  user(fork(fun (s) {serve(s)}))
+  user(forkSync(fun (s) {serve(s)}))
 }
 
 serveData(goodMe)

--- a/examples/AIPL14/SMTP/Problem1.links
+++ b/examples/AIPL14/SMTP/Problem1.links
@@ -60,7 +60,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/SMTP/Problem2.links
+++ b/examples/AIPL14/SMTP/Problem2.links
@@ -64,7 +64,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/SMTP/Problem3.links
+++ b/examples/AIPL14/SMTP/Problem3.links
@@ -72,7 +72,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/SMTP/Problem4.links
+++ b/examples/AIPL14/SMTP/Problem4.links
@@ -96,7 +96,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/Solutions/Problem1.links
+++ b/examples/AIPL14/Solutions/Problem1.links
@@ -88,7 +88,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/Solutions/Problem2.links
+++ b/examples/AIPL14/Solutions/Problem2.links
@@ -126,7 +126,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/Solutions/Problem3.links
+++ b/examples/AIPL14/Solutions/Problem3.links
@@ -117,7 +117,7 @@ fun mailClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/AIPL14/Solutions/Problem4.links
+++ b/examples/AIPL14/Solutions/Problem4.links
@@ -158,7 +158,7 @@ fun rcptLoopClient(c) {
 }
 
 fun main() {
-  mailClient(fork(mailServer))
+  mailClient(forkSync(mailServer))
 }
 
 main()

--- a/examples/client-server-prims.links
+++ b/examples/client-server-prims.links
@@ -1,10 +1,10 @@
 # A test of client stubs / server stubs called from the other side.
 fun f() client {
-  alertDialog(intToString(serverTime()))
+  print(intToString(serverTime()))
 }
 
 fun g() server {
-  alertDialog("this is the server talking.")
+  print("this is the server talking.")
 }
 
 page

--- a/examples/games/tetris.links
+++ b/examples/games/tetris.links
@@ -830,4 +830,3 @@ fun main() {
         </html>
 }
 
-main()

--- a/examples/initialise-list.links
+++ b/examples/initialise-list.links
@@ -46,7 +46,7 @@ fun product(xs) {
 }
 ### end of library functions ###
 
-#fun select(xs, i) {
+#fun sel(xs, i) {
 #  var n = length(xs);
 #  if (i < 0 || n <= i) {
 #    error("list index " ^^ intToString(i) ^^ " out of range [0.."
@@ -63,7 +63,7 @@ fun product(xs) {
 #  }
 #}
 
-fun select(xs, i) {
+fun sel(xs, i) {
   hd(drop(i, xs))
 }
 
@@ -82,7 +82,7 @@ fun insertItems(itemsTable, itemsList) {
   var indexes = for (itemEntry <- asList(itemsTable)) [itemEntry.i];
   insert itemsTable values (i, name)
     for (i <- upto(0,n-1) `diff` indexes)
-      [(i=i, name=select(itemsList, i))];
+      [(i=i, name=sel(itemsList, i))];
 }
 
 # `diff` is list difference

--- a/examples/sessions/Elvina/Bookshop_1.links
+++ b/examples/sessions/Elvina/Bookshop_1.links
@@ -6,14 +6,14 @@ sig waitForClient : (ShopOffer) ~> ()
 fun waitForClient(s) client
 {
 	offer(s) {
-		case Add(s)      -> 
+		case Add(s)      ->
 			var (item, s) = receive(s);
 			appendChildren(stringToXml("Book name received: " ^^ item), getNodeById("items"));
 			waitForClient(s)
 
-		case Checkout(s) -> 
+		case Checkout(s) ->
 			var (card, s)    = receive(s);
-			appendChildren(stringToXml(", card number received: " ^^ intToString(card)), getNodeById("items")); 
+			appendChildren(stringToXml(", card number received: " ^^ intToString(card)), getNodeById("items"));
 			var (address, s) = receive(s);
 			appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
 			()
@@ -31,7 +31,7 @@ fun orderBooks(c) client
 sig main : () ~> ()
 fun main() client
 {
-	orderBooks(knife(waitForClient))
+	orderBooks(fork(waitForClient))
 }
 
 
@@ -41,7 +41,7 @@ page
 	<body>
 	<form l:onsubmit="{main()}">
 	<h3>Example 1 from "Linear type theory for asynchronous session types":</h3>
-	<button type="submit">Start communication</button>	
+	<button type="submit">Start communication</button>
 	</form>
 	<p id="items"></p>
 	</body>

--- a/examples/sessions/Elvina/Bookshop_2.links
+++ b/examples/sessions/Elvina/Bookshop_2.links
@@ -11,14 +11,14 @@ sig waitForClient : (ShopOffer) ~> ()
 fun waitForClient(s) client
 {
 	offer(s) {
-		case Add(s)      -> 
+		case Add(s)      ->
 			var (item, s) = receive(s);
 			appendChildren(stringToXml("Book name received: " ^^ item ^^ ", "), getNodeById("items"));
 			waitForClient(s)
 
-		case Checkout(s) -> 
+		case Checkout(s) ->
 			var (card, s)    = receive(s);
-			appendChildren(stringToXml("card number received: " ^^ intToString(card)), getNodeById("items")); 
+			appendChildren(stringToXml("card number received: " ^^ intToString(card)), getNodeById("items"));
 			var (address, s) = receive(s);
 			appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
 			()
@@ -48,7 +48,7 @@ fun orderBooks(c) client
 	var c = send("Alice in Wonderland", select Add c);
 
 	# "Son's choice".
-	var choice = getSonBook(knife(waitForSon));
+	var choice = getSonBook(fork(waitForSon));
 
 	# Add son's choice.
 	var c = send(choice, select Add c);
@@ -59,7 +59,7 @@ fun orderBooks(c) client
 sig main : () ~> ()
 fun main() client
 {
-	orderBooks(knife(waitForClient))
+	orderBooks(fork(waitForClient))
 }
 
 page
@@ -68,7 +68,7 @@ page
 	<body>
 	<form l:onsubmit="{main()}">
 	<h3>Example 2 from "Linear type theory for asynchronous session types":</h3>
-	<button type="submit">Start communication</button>	
+	<button type="submit">Start communication</button>
 	</form>
 	<p id="items"></p>
 	</body>

--- a/examples/sessions/Elvina/Bookshop_3.links
+++ b/examples/sessions/Elvina/Bookshop_3.links
@@ -33,24 +33,24 @@ typename SonOffer  = [+|Choice:?Product.End|+];
 sig waitForClient : (ShopOffer, [Product], String) ~> ()
 fun waitForClient(s, orderedProducts, removedProducts) client
 {
-	
+
 offer(s) {
-case Add(s) -> 
+case Add(s) ->
 	var (item, s) = receive(s);					# Accepts order for an item.
 	waitForClient(s, item::orderedProducts, removedProducts)
 
 case Remove(s) ->
 	var (item, s) = receive(s);
 	var updatedList = removeProduct(item, orderedProducts);
-	
+
 	# See if the list is smaller (= an item to be removed was actually in a list).
 	if (length(updatedList) < length(orderedProducts))
 	   waitForClient(s, updatedList, removedProducts ^^ turnProductToString(item) ^^ ". ")
 	else
 	   waitForClient(s, orderedProducts, removedProducts)
-		
 
-case Checkout(s) -> 
+
+case Checkout(s) ->
 	var (card, s)    = receive(s);		# Take credit card information.
 	var (addressFull, s) = shipper(s);	# Contact shipper, send it the channel to receive address.
 
@@ -133,13 +133,13 @@ sig orderBooks : (ShopSelect) ~> ([String])
 fun orderBooks(c) client
 {
 	var myAddress = (street="Princes Street", houseNo=14, city="Edinburgh");
-	
+
 	# "Mom's choice".
 	var c = send(Book("Alice in Wonderland"), select Add c);
 	var c = send(Audio_Visual("The Hitchhiker's Guide to the Galaxy"), select Add c);
 
 	# "Son's choice".
-	var choice = getSonBook(knife(waitForSon));
+	var choice = getSonBook(fork(waitForSon));
 
 	# Add son's choice.
 	var c = send(choice, select Add c);
@@ -157,7 +157,7 @@ fun orderBooks(c) client
 sig main : () ~> ()
 fun main() client
 {
-	var order = orderBooks(knife(fun(s){waitForClient(s, [], "")}));
+	var order = orderBooks(fork(fun(s){waitForClient(s, [], "")}));
 	appendChildren(stringToXml(order!!0), getNodeById("items"));
 	appendChildren(stringToXml(order!!1), getNodeById("removed"));
 	appendChildren(stringToXml(order!!2), getNodeById("cardNo"));
@@ -170,7 +170,7 @@ page
 	<body>
 	<form l:onsubmit="{main()}">
 	<h3>Finished example from "Linear type theory for asynchronous session types":</h3>
-	<button type="submit">Start communication</button>	
+	<button type="submit">Start communication</button>
 	</form>
 	<p><b>Products ordered:</b></p>
 	<p id="items"></p>

--- a/examples/sessions/Elvina/Extended_Calculator.links
+++ b/examples/sessions/Elvina/Extended_Calculator.links
@@ -36,19 +36,19 @@ fun user(s, op1, op2, operation) client {
 		case "mult" -> { var s = select Mul s; receive(send(op1,send(op2,s))).1 }
 		case "sub" -> { var s = select Sub s; receive(send(op1,send(op2,s))).1 }
 		case "div" -> { var s = select Div s; receive(send(op1,send(op2,s))).1 }
-	}	 		
+	}
 }
 
 sig main : (String, String, String) ~> Int
 fun main(op1, op2, operation) client {
-  user(knife(calc), stringToInt(op1), stringToInt(op2), operation)
+  user(fork(calc), stringToInt(op1), stringToInt(op2), operation)
 }
 
 page
   <html>
   <head><title>[10] Cool Calculator </title></head>
   <body>
-  <h3>Cool Integer Calculator</h3> 
+  <h3>Cool Integer Calculator</h3>
 
    <form l:onsubmit="{domReplaceChildren(stringToXml(intToString(main(op1, op2, operation))), getNodeById("result"))}">
     <input type="text" size="5" l:name="op1"/>
@@ -57,10 +57,10 @@ page
   	<option value="mult">*</option>
 	<option value="sub">-</option>
   	<option value="div">/</option>
-   </select> 
+   </select>
     <input type="text" size="5" l:name="op2"/>
     <button type="submit">Get Result!</button>
-   </form>		  
+   </form>
 
    <p>The result is:</p>
    <p id="result"></p>

--- a/examples/sessions/Elvina/IRC.links
+++ b/examples/sessions/Elvina/IRC.links
@@ -258,6 +258,6 @@ fun readServerAccumulate(rs, time, timeout, answer) {
 }
 
 fun startCommunication() {
-	ircClient(fork(ircServer))
+	ircClient(forkSync(ircServer))
 }
 startCommunication()

--- a/examples/sessions/Elvina/SMTP_Real_CP.links
+++ b/examples/sessions/Elvina/SMTP_Real_CP.links
@@ -32,7 +32,7 @@ fun mailServer(s) {
   #var welcomeMessage = readFromSocket(realServer);
   var welcomeMessage = readServer(realServer);
   println("S: " ^^ welcomeMessage);
-  start(s, realServer) 
+  start(s, realServer)
 }
 
 fun start(s, realServer) {
@@ -69,12 +69,12 @@ fun outer(s, realServer) {
 						<| ACCEPT s.{rcptLoop(s, realServer)} |>
 					}
 	}
-	case QUIT -> { 
+	case QUIT -> {
 	     println("C: QUIT");
        writeToSocket("QUIT\n", realServer);
        var smtpAnswer = readServer(realServer);
        println("S: " ^^ smtpAnswer);
-       closeSocket(realServer); <| s[] |> } 
+       closeSocket(realServer); <| s[] |> }
 
   } |>
 }
@@ -116,7 +116,7 @@ fun inner(s, realServer) {
 	  writeToSocket("DATA\n", realServer);
       #var smtpAnswer = readFromSocket(realServer);
       var smtpAnswer = readServer(realServer);
-      println("S: " ^^ smtpAnswer);   
+      println("S: " ^^ smtpAnswer);
       writeToSocket("SUBJECT: " ^^ subject ^^ "\n", realServer);
       println("C: SUBJECT: " ^^ subject);
       writeToSocket(message ^^ "\n", realServer);
@@ -126,10 +126,10 @@ fun inner(s, realServer) {
       #var smtpAnswer = readFromSocket(realServer);
       var smtpAnswer = readServer(realServer);
       println("S: " ^^ smtpAnswer);
-      outer(s, realServer) } 
+      outer(s, realServer) }
 
-  } |> 
-} 
+  } |>
+}
 
 
 sig parseServerAnswer : (String) ~> Int
@@ -214,7 +214,7 @@ fun addOtherRecipients(c, mail_form, return) {
 
 fun rcptLoopClient(c, mail_form, return) {
   switch(mail_form.2) {
-    case x::xs -> 
+    case x::xs ->
     	<| RCPT c.c[x].{ println("C: RCPT TO:<" ^^ x ^^ ">");
             <| offer c {
                 case REJECT -> {var mail_form = (mail_form.1, xs, mail_form.3, mail_form.4);
@@ -230,8 +230,8 @@ fun rcptLoopClient(c, mail_form, return) {
 sig startCommunication : (String, [String], String, String) ~> ()
 fun startCommunication(sender, recipients, subject, message) {
     var mail_form = (sender, recipients, subject, message);
-    run (fun(return){<| nu s.({mailServer(s)}|{mailClient(s, mail_form, return)}) |>})
+    runSync (fun(return){<| nu s.({mailServer(s)}|{mailClient(s, mail_form, return)}) |>})
 }
 
-startCommunication("smtp@links.co.uk", ["starlight@dust", "something@someOther.com"], 
+startCommunication("smtp@links.co.uk", ["starlight@dust", "something@someOther.com"],
                    "Links SMTP Client Test", "Hello\nHow are you?")

--- a/examples/sessions/Elvina/SMTP_Real_GV.links
+++ b/examples/sessions/Elvina/SMTP_Real_GV.links
@@ -32,19 +32,19 @@ fun mailServer(s) {
   #var welcomeMessage = readFromSocket(realServer);
   var welcomeMessage = readServer(realServer);
   print("S: " ^^ welcomeMessage);
-  start(s, realServer) 
+  start(s, realServer)
 }
 
 fun start(s, realServer) {
 offer(s) {
-  case HELO(s) ->             
+  case HELO(s) ->
          var (domain, s) = receive(s);
          writeToSocket("HELO " ^^ domain ^^ "\n", realServer);
          #var smtpAnswer = readFromSocket(realServer);
          var smtpAnswer = readServer(realServer);
          print("S: " ^^ smtpAnswer);
          var status = parseServerAnswer(smtpAnswer);
-           if (status <> 250) 
+           if (status <> 250)
               { var s = select REJECT s;
                 print("S: " ^^ smtpAnswer);
                 mailServer(s)
@@ -65,7 +65,7 @@ offer(s) {
     var smtpAnswer = readServer(realServer);
     print("S: " ^^ smtpAnswer);
     var status = parseServerAnswer(smtpAnswer);
-    if (status <> 250) 
+    if (status <> 250)
        { var s = select REJECT s;
        print("S: " ^^ smtpAnswer);
        outer(s, realServer)
@@ -94,12 +94,12 @@ fun rcptLoop(s, realServer) {
         var smtpAnswer = readServer(realServer);
         print("S: " ^^ smtpAnswer);
         var status = parseServerAnswer(smtpAnswer);
-        if (status <> 250) 
+        if (status <> 250)
            { var s = select REJECT s;
            print("S: " ^^ smtpAnswer);
            rcptLoop(s, realServer)
            }
-        else {    
+        else {
            var s = select ACCEPT s;
            inner(s, realServer)
     }
@@ -115,12 +115,12 @@ fun inner(s, realServer) {
         var smtpAnswer = readServer(realServer);
         print("S: " ^^ smtpAnswer);
         var status = parseServerAnswer(smtpAnswer);
-        if (status <> 250) 
+        if (status <> 250)
            { var s = select REJECT s;
            print("S: " ^^ smtpAnswer);
            inner(s, realServer)
             }
-        else {    
+        else {
            var s = select ACCEPT s;
           inner(s, realServer)
   }
@@ -131,7 +131,7 @@ fun inner(s, realServer) {
       writeToSocket("DATA\n", realServer);
       #var smtpAnswer = readFromSocket(realServer);
       var smtpAnswer = readServer(realServer);
-      print("S: " ^^ smtpAnswer);   
+      print("S: " ^^ smtpAnswer);
       writeToSocket("SUBJECT: " ^^ subject ^^ "\n", realServer);
       print("C: SUBJECT: " ^^ subject);
       writeToSocket(message ^^ "\n", realServer);
@@ -142,8 +142,8 @@ fun inner(s, realServer) {
       var smtpAnswer = readServer(realServer);
       print("S: " ^^ smtpAnswer);
       outer(s, realServer)
-   } 
-} 
+   }
+}
 
 fun readServer(realServer) {
   #var smtpAnswer = readFromSocket(realServer);
@@ -253,8 +253,8 @@ fun rcptLoopClient(c, mail_form) {
 sig startCommunication : (String, [String], String, String) ~> ()
 fun startCommunication(sender, recipients, subject, message) {
     var mail_form = (sender, recipients, subject, message);
-    mailClient(fork(mailServer), mail_form)
+    mailClient(forkSync(mailServer), mail_form)
 }
 
-startCommunication("smtp@links.co.uk", ["starlight@dust", "something@someOther.com"], 
+startCommunication("smtp@links.co.uk", ["starlight@dust", "something@someOther.com"],
                    "Links SMTP Client Test", "Hello\nHow are you?")

--- a/examples/sessions/atm.links
+++ b/examples/sessions/atm.links
@@ -69,7 +69,7 @@ fun user2(c) {
 sig user3 : (~ATM) ~> Maybe(Int)
 fun user3(c) {
   offer (send(1024, send(16777216, c))) {
-    case Accept(c) ->      
+    case Accept(c) ->
       var (balance, c) = receive(select Balance c);
       var (card, c) = receive(c); Just(balance)
     case Reject(c) ->
@@ -78,6 +78,6 @@ fun user3(c) {
 }
 
 
-(user1(knife(fun (c) {atm(128, c)})),
- user2(knife(fun (c) {atm(128, c)})),
- user3(knife(fun (c) {atm(128, c)})))
+(user1(fork(fun (c) {atm(128, c)})),
+ user2(fork(fun (c) {atm(128, c)})),
+ user3(fork(fun (c) {atm(128, c)})))

--- a/examples/sessions/counter.links
+++ b/examples/sessions/counter.links
@@ -34,4 +34,4 @@ fun main() {
   for (i <- [1..10]) [recv()]
 }
 
-main()
+spawnWait { main() }

--- a/test-harness
+++ b/test-harness
@@ -80,7 +80,7 @@ def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = Non
                 if ignore <> None:
                     global ignored
                     ignored += 1
-                    print '?IGNORED: %s' % ignore
+                    print '?IGNORED: %s (%s)' % (name, ignore)
                 else:
                     global failures
                     failures += 1

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -2,67 +2,60 @@ Typecheck example file examples/AIPL14/LectureExamples/calc.links
 examples/AIPL14/LectureExamples/calc.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/LectureExamples/reccalc.links
 examples/AIPL14/LectureExamples/reccalc.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/LectureExamples/two-factor.links
 examples/AIPL14/LectureExamples/two-factor.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/SMTP/Problem1.links
 examples/AIPL14/SMTP/Problem1.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
+ignore : purposely incomplete
 
 Typecheck example file examples/AIPL14/SMTP/Problem2.links
 examples/AIPL14/SMTP/Problem2.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
+ignore : purposely incomplete
 
 Typecheck example file examples/AIPL14/SMTP/Problem3.links
 examples/AIPL14/SMTP/Problem3.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
+ignore : purposely incomplete
 
 Typecheck example file examples/AIPL14/SMTP/Problem4.links
 examples/AIPL14/SMTP/Problem4.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
+ignore : purposely incomplete
 
 Typecheck example file examples/AIPL14/Solutions/Problem1.links
 examples/AIPL14/Solutions/Problem1.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/Solutions/Problem2.links
 examples/AIPL14/Solutions/Problem2.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/Solutions/Problem3.links
 examples/AIPL14/Solutions/Problem3.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/AIPL14/Solutions/Problem4.links
 examples/AIPL14/Solutions/Problem4.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/buttons.links
 examples/buttons.links
@@ -89,7 +82,6 @@ Typecheck example file examples/client-server-prims.links
 examples/client-server-prims.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/crop.links
 examples/crop.links
@@ -175,7 +167,6 @@ Typecheck example file examples/distribution/simpleServerAP.links
 examples/distribution/simpleServerAP.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/document-replace.links
 examples/document-replace.links
@@ -236,7 +227,6 @@ Typecheck example file examples/games/tetris.links
 examples/games/tetris.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/games/twentyfortyeight.links
 examples/games/twentyfortyeight.links
@@ -444,7 +434,6 @@ Typecheck example file examples/initialise-list.links
 examples/initialise-list.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/insert-factorials.links
 examples/insert-factorials.links
@@ -515,7 +504,6 @@ Typecheck example file examples/sessions/atm.links
 examples/sessions/atm.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config
-ignore : broken example
 
 Typecheck example file examples/sessions/bookshop-cp.links
 examples/sessions/bookshop-cp.links
@@ -565,14 +553,12 @@ args : --config=tests/typecheck_examples.tests.config
 Typecheck example file examples/sessions/chatserver/chatClient.links
 examples/sessions/chatserver/chatClient.links
 filemode : args
-args : --config=tests/typecheck_examples.tests.config --path=examples/distribution/chatserver
-ignore : broken example
+args : --config=tests/typecheck_examples.tests.config --path=examples/sessions/chatserver
 
 Typecheck example file examples/sessions/chatserver/chatServer.links
 examples/sessions/chatserver/chatServer.links
 filemode : args
 args : --config=tests/typecheck_examples.tests.config --path=/examples/sessions/chatserver/
-ignore : broken example
 
 Typecheck example file examples/sessions/chatserver/chatSessions.links
 examples/sessions/chatserver/chatSessions.links


### PR DESCRIPTION
I couldn't get `examples/sessions/draggable-boring.links` to work,
primarily because I don't know the history of CP syntax. All other
sessions and distribution examples should work though.